### PR TITLE
feat(fastapi-echo): add binary-echo endpoint and large payload test

### DIFF
--- a/examples/function_samples/fastapi_echo_sample/README.md
+++ b/examples/function_samples/fastapi_echo_sample/README.md
@@ -1,27 +1,164 @@
-# FastAPI Sample
-## Build the sample container
+# FastAPI Echo Sample
+
+A lightweight FastAPI container with three endpoints:
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/health` | GET | Health check (returns `{"status": "OK"}`) |
+| `/echo` | POST | JSON echo with optional streaming and repeat |
+| `/binary-echo` | POST | Binary pass-through -- returns the raw request body with integrity metadata headers |
+
+## Build
+
 ```bash
-docker buildx build --platform linux/amd64,linux/arm64 -t fastapi_echo_sample .
-```
-To upload it to NGC refer to [here](https://docs.nvidia.com/cloud-functions/user-guide/latest/cloud-function/quickstart.html#clone-build-and-push-the-docker-image-to-ngc-private-registry)
-
-## Invoke the sample locally
-```bash 
-curl --request POST \
-  --url localhost:8000/echo \
-  --header 'Content-Type: application/json' \
-  --data '{
-  "message": "hello"
-}'
+docker build . -t fastapi_echo_sample:latest
 ```
 
-## Invoke the sample in NVCF
-```bash 
-curl --request POST \
-  --url https://<function-id>.invocation.api.nvcf.nvidia.com/echo \
-  --header 'Authorization: Bearer nvapi-<token>' \
-  --header 'Content-Type: application/json' \
-  --data '{
-  "message": "hello"
-}'
+For cross-platform builds (e.g., building on Apple Silicon for an x86 cluster):
+
+```bash
+docker buildx build --platform linux/amd64 -t fastapi_echo_sample:latest .
+```
+
+## Push to NGC
+
+```bash
+docker tag fastapi_echo_sample:latest nvcr.io/<org-id>/fastapi_echo_sample:<tag>
+docker push nvcr.io/<org-id>/fastapi_echo_sample:<tag>
+```
+
+See the [NGC container registry docs](https://docs.nvidia.com/cloud-functions/user-guide/latest/cloud-function/quickstart.html#clone-build-and-push-the-docker-image-to-ngc-private-registry) for authentication details.
+
+## Test locally
+
+```bash
+docker run --rm -p 8000:8000 fastapi_echo_sample:latest
+```
+
+JSON echo:
+
+```bash
+curl -X POST http://localhost:8000/echo \
+  -H 'Content-Type: application/json' \
+  -d '{"message": "hello"}'
+```
+
+Binary echo:
+
+```bash
+echo "hello world" | curl -X POST http://localhost:8000/binary-echo \
+  -H 'Content-Type: application/octet-stream' \
+  --data-binary @- -v
+```
+
+## Deploy to NVCF
+
+### Step 1: Create the function
+
+```bash
+curl -s -X POST 'https://api.ngc.nvidia.com/v2/nvcf/functions' \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H "Authorization: Bearer $API_KEY" \
+  -d '{
+    "name": "fastapi-echo",
+    "inferenceUrl": "/echo",
+    "inferencePort": 8000,
+    "containerImage": "nvcr.io/<org-id>/fastapi_echo_sample:<tag>",
+    "apiBodyFormat": "CUSTOM",
+    "health": {
+      "protocol": "HTTP",
+      "uri": "/health",
+      "port": 8000,
+      "timeout": "PT30S",
+      "expectedStatusCode": 200
+    }
+  }'
+```
+
+Save the `id` (function ID) and `versionId` from the response.
+
+### Step 2: Deploy
+
+```bash
+curl -s -X POST "https://api.ngc.nvidia.com/v2/nvcf/deployments/functions/$FUNCTION_ID/versions/$VERSION_ID" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H "Authorization: Bearer $API_KEY" \
+  -d '{
+    "deploymentSpecifications": [
+      {
+        "gpu": "<gpu-type>",
+        "instanceType": "<instance-type>",
+        "backend": "<cluster-group-name>",
+        "minInstances": 1,
+        "maxInstances": 1,
+        "maxRequestConcurrency": 1
+      }
+    ]
+  }'
+```
+
+Replace `<gpu-type>`, `<instance-type>`, and `<cluster-group-name>` with values
+from your cluster group (see `GET /v2/nvcf/clusterGroups`).
+
+### Step 3: Wait for ACTIVE status
+
+```bash
+curl -s "https://api.ngc.nvidia.com/v2/nvcf/functions/$FUNCTION_ID/versions/$VERSION_ID" \
+  -H "Authorization: Bearer $API_KEY" | jq '.function.status'
+```
+
+## Invoke via direct invocation
+
+Once the function is ACTIVE, call it through the direct invocation endpoint.
+This bypasses the legacy `/pexec` path -- no Protobuf wrapping, no size limits,
+native streaming.
+
+JSON echo:
+
+```bash
+curl -X POST "https://${FUNCTION_ID}.invocation.api.nvcf.nvidia.com/echo" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"message": "hello", "repeats": 3}'
+```
+
+Binary echo:
+
+```bash
+curl -X POST "https://${FUNCTION_ID}.invocation.api.nvcf.nvidia.com/binary-echo" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H 'Content-Type: application/octet-stream' \
+  --data-binary @my-file.bin -v
+```
+
+The response body is the same bytes you sent. Check the response headers for
+integrity metadata:
+
+- `X-Echo-Size` -- byte count
+- `X-Echo-MD5` -- MD5 hex digest
+- `X-Echo-Content-Type` -- echoed content type
+
+## Large binary streaming test
+
+`test-binary-streaming.sh` validates that large payloads round-trip correctly
+through direct invocation. It generates random payloads at 50KB, 1MB, 10MB, and
+50MB, sends each to `/binary-echo`, and compares MD5 checksums.
+
+```bash
+FUNCTION_ID="<function-id>" API_KEY="nvapi-<token>" ./test-binary-streaming.sh
+```
+
+Example output:
+
+```
+TEST      HTTP    LATENCY     SENT MD5                            RECV MD5                            RESULT
+--------------------------------------------------------------------------------------------------------------
+50KB      200        1028ms  b4f4b4712d7d32fdf8db1103cc671345    b4f4b4712d7d32fdf8db1103cc671345    PASS
+1MB       200        2204ms  0370b8d28bb874a9feb20574b4bc2709    0370b8d28bb874a9feb20574b4bc2709    PASS
+10MB      200        2891ms  b80bf7b726b4e818aa27884c572424c9    b80bf7b726b4e818aa27884c572424c9    PASS
+50MB      200       10066ms  eb43f17ff00461d08488fe4dffc55f55    eb43f17ff00461d08488fe4dffc55f55    PASS
+--------------------------------------------------------------------------------------------------------------
+Results: 4 passed, 0 failed
 ```

--- a/examples/function_samples/fastapi_echo_sample/http_echo_server.py
+++ b/examples/function_samples/fastapi_echo_sample/http_echo_server.py
@@ -1,8 +1,9 @@
+import hashlib
 import os
 import time
 import uvicorn
 from pydantic import BaseModel
-from fastapi import FastAPI, status
+from fastapi import FastAPI, Request, Response, status
 from fastapi.responses import StreamingResponse
 
 
@@ -33,6 +34,20 @@ async def echo(echo: Echo):
     else:
         time.sleep(echo.delay)
         return echo.message*echo.repeats
+
+@app.post("/binary-echo")
+async def binary_echo(request: Request):
+    body = await request.body()
+    md5 = hashlib.md5(body).hexdigest()
+    return Response(
+        content=body,
+        media_type=request.headers.get("content-type", "application/octet-stream"),
+        headers={
+            "X-Echo-Size": str(len(body)),
+            "X-Echo-MD5": md5,
+            "X-Echo-Content-Type": request.headers.get("content-type", "application/octet-stream"),
+        },
+    )
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8000, workers=int(os.getenv('WORKER_COUNT', 500)))

--- a/examples/function_samples/fastapi_echo_sample/test-binary-streaming.sh
+++ b/examples/function_samples/fastapi_echo_sample/test-binary-streaming.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# test-binary-streaming.sh -- validate large binary payloads via direct invocation
+#
+# Required env vars:
+#   FUNCTION_ID  -- the NVCF function ID
+#   API_KEY      -- NGC API key (nvapi-...)
+#
+# Usage:
+#   FUNCTION_ID="abc-123" API_KEY="nvapi-..." ./test-binary-streaming.sh
+
+set -euo pipefail
+
+: "${FUNCTION_ID:?Set FUNCTION_ID}"
+: "${API_KEY:?Set API_KEY}"
+
+BASE_URL="https://${FUNCTION_ID}.invocation.api.nvcf.nvidia.com"
+TMPDIR_BASE=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+# ---------- helpers ----------
+
+generate_payload() {
+    local size_bytes=$1 path=$2
+    dd if=/dev/urandom of="$path" bs=1024 count=$((size_bytes / 1024)) 2>/dev/null
+}
+
+md5_of() {
+    md5 -q "$1" 2>/dev/null || md5sum "$1" | awk '{print $1}'
+}
+
+# ---------- test matrix ----------
+
+declare -a NAMES=("50KB" "1MB" "10MB" "50MB")
+declare -a SIZES=(51200 1048576 10485760 52428800)
+
+PASS=0
+FAIL=0
+
+printf "\n%-8s  %-6s  %-10s  %-34s  %-34s  %s\n" \
+    "TEST" "HTTP" "LATENCY" "SENT MD5" "RECV MD5" "RESULT"
+printf '%0.s-' {1..110}; echo
+
+for i in "${!NAMES[@]}"; do
+    name="${NAMES[$i]}"
+    size="${SIZES[$i]}"
+    payload="$TMPDIR_BASE/payload-${name}"
+
+    generate_payload "$size" "$payload"
+    sent_md5=$(md5_of "$payload")
+
+    resp_file="$TMPDIR_BASE/resp-${name}"
+    header_file="$TMPDIR_BASE/headers-${name}"
+
+    start=$(python3 -c 'import time; print(int(time.time()*1000))')
+
+    http_code=$(curl -s -o "$resp_file" -D "$header_file" -w "%{http_code}" \
+        -X POST "${BASE_URL}/binary-echo" \
+        -H "Authorization: Bearer ${API_KEY}" \
+        -H "Content-Type: application/octet-stream" \
+        --data-binary @"$payload" \
+        --max-time 300)
+
+    end=$(python3 -c 'import time; print(int(time.time()*1000))')
+    latency=$(( end - start ))
+
+    recv_md5=$(md5_of "$resp_file")
+
+    if [[ "$http_code" == "200" && "$sent_md5" == "$recv_md5" ]]; then
+        result="PASS"
+        ((PASS++))
+    else
+        result="FAIL"
+        ((FAIL++))
+    fi
+
+    printf "%-8s  %-6s  %7dms  %-34s  %-34s  %s\n" \
+        "$name" "$http_code" "$latency" "$sent_md5" "$recv_md5" "$result"
+done
+
+printf '%0.s-' {1..110}; echo
+printf "Results: %d passed, %d failed\n\n" "$PASS" "$FAIL"
+
+if [[ "$FAIL" -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
Add a /binary-echo endpoint that echoes raw bytes with integrity metadata headers (X-Echo-Size, X-Echo-MD5, X-Echo-Content-Type). Include test-binary-streaming.sh to validate large payloads (up to 50MB) round-trip correctly through direct invocation.

Update README with end-to-end deployment and invocation steps using the NGC API and direct invocation endpoint.